### PR TITLE
Bugfix/Fix permission request

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="za.co.social_engineer.www.socialengineer">
-    
+
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
@@ -38,10 +38,13 @@
             android:name=".activity.TrainingActivity"
             android:screenOrientation="portrait" />
         <provider
-            android:authorities="za.co.social_engineer.www.socialengineer"
-            android:name=".util.PDFContentProvider"
-            android:exported="true"
-            android:grantUriPermissions="true">
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="za.co.social_engineer.www.socialengineer.fileProvider"
+            android:grantUriPermissions="true"
+            android:exported="false">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
         </provider>
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="za.co.social_engineer.www.socialengineer">
-
-    <uses-permission android:name="android.permission.INTERNET" />
+    
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 

--- a/app/src/main/java/za/co/social_engineer/www/socialengineer/activity/TrainingActivity.java
+++ b/app/src/main/java/za/co/social_engineer/www/socialengineer/activity/TrainingActivity.java
@@ -1,10 +1,17 @@
 package za.co.social_engineer.www.socialengineer.activity;
 
-import android.content.Context;
+import android.Manifest;
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
+import android.support.design.widget.Snackbar;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.content.FileProvider;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
@@ -22,6 +29,10 @@ import za.co.social_engineer.www.socialengineer.R;
 public class TrainingActivity extends AppCompatActivity {
 
     private static final String TAG = "TrainingActivity";
+
+    private static final int MY_PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE = 0;
+
+    private String selectedTrainingDocument;
 
     private ListView trainingDocumentsListView;
 
@@ -53,42 +64,70 @@ public class TrainingActivity extends AppCompatActivity {
         trainingDocumentsListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                String selectedTrainingDocument = trainingDocumentAdapter.getItem(position);
+                selectedTrainingDocument = trainingDocumentAdapter.getItem(position);
 
-                if (isExternalStorageWritable()) {
-                    File trainingDir = getDocumentStorageDir(view.getContext(), "training");
+                // Check if app has permission to write to external storage, if not, request permission
+                if (ContextCompat.checkSelfPermission(TrainingActivity.this,
+                        Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                        != PackageManager.PERMISSION_GRANTED) {
 
-                    File file = new File(trainingDir.getAbsolutePath() + "/" + selectedTrainingDocument
-                            + ".pdf");
-
-                    if (!file.exists()) {
-                        try {
-                            InputStream inputStream = getResources().getAssets().open("training/" +
-                                    selectedTrainingDocument + ".pdf");
-
-                            int size = inputStream.available();
-                            byte[] buffer = new byte[size];
-                            inputStream.read(buffer);
-                            inputStream.close();
-
-                            FileOutputStream fileOutputStream = new FileOutputStream(file);
-                            fileOutputStream.write(buffer);
-                            fileOutputStream.close();
-                        } catch (IOException e) {
-                            Log.e(TAG, e.getMessage());
-                        }
-                    }
-
-                    Intent intent = new Intent(Intent.ACTION_VIEW);
-                    //intent.setDataAndType(FileProvider.getUriForFile(TrainingActivity.this,
-                            //BuildConfig.APPLICATION_ID + ".provider", file.get), "application/pdf");
-                    Uri uri = Uri.parse("content://za.co.social_engineer.www.socialengineer/" + file.getAbsolutePath());
-                    intent.setDataAndType(uri, "application/pdf");
-                    intent.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-                    startActivity(intent);
+                    ActivityCompat.requestPermissions(TrainingActivity.this,
+                            new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                            MY_PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE);
+                } else {
+                    displayPDF();
                 }
             }
         });
+    }
+
+    /* Launches external PDF reader to view the selected training document */
+    public void displayPDF() {
+        if (isExternalStorageWritable()) {
+            File trainingDir = getDocumentStorageDir("SEPTT/Training");
+
+            File file = new File(trainingDir.getAbsolutePath() + "/" + selectedTrainingDocument
+                    + ".pdf");
+
+            if (!file.exists()) {
+                try {
+                    InputStream inputStream = getResources().getAssets().open("training/" +
+                            selectedTrainingDocument + ".pdf");
+
+                    int size = inputStream.available();
+                    byte[] buffer = new byte[size];
+                    inputStream.read(buffer);
+                    inputStream.close();
+
+                    FileOutputStream fileOutputStream = new FileOutputStream(file);
+                    fileOutputStream.write(buffer);
+                    fileOutputStream.close();
+                } catch (IOException e) {
+                    Log.e(TAG, e.getMessage());
+                }
+            }
+
+            //intent.setDataAndType(FileProvider.getUriForFile(TrainingActivity.this,
+            //BuildConfig.APPLICATION_ID + ".provider", file.get), "application/pdf");
+
+            //Uri uri = Uri.parse("content://za.co.social_engineer.www.socialengineer/" + file.getAbsolutePath());
+
+            try {
+                Intent intent = new Intent(Intent.ACTION_VIEW);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                    Uri uri = FileProvider.getUriForFile(TrainingActivity.this,
+                            "za.co.social_engineer.www.socialengineer.fileProvider", file);
+                    intent.setDataAndType(uri, "application/pdf");
+                } else {
+                    intent.setDataAndType(Uri.fromFile(file), "application/pdf");
+                }
+                startActivity(intent);
+            } catch (ActivityNotFoundException e) {
+                Snackbar noPDFViewerSnackbar = Snackbar.make(getCurrentFocus(), "No PDF Viewer installed on device. Please install a PDF Viewer and try again.", Snackbar.LENGTH_LONG);
+                noPDFViewerSnackbar.show();
+            }
+        }
     }
 
     /* Checks if external storage is available for read and write */
@@ -100,13 +139,29 @@ public class TrainingActivity extends AppCompatActivity {
         return false;
     }
 
-    public File getDocumentStorageDir(Context context, String documentStorageSubDir) {
-        // Get the directory for the app's private pictures directory.
-        File file = new File(context.getExternalFilesDir(
-                Environment.DIRECTORY_DOCUMENTS), documentStorageSubDir);
+    public File getDocumentStorageDir(String septtStorageSubDir) {
+        // Get the directory for the app's public directory.
+        File file = new File(Environment.getExternalStorageDirectory(),
+                septtStorageSubDir);
         if (!file.mkdirs()) {
             Log.i(TAG, "Directory not created");
         }
         return file;
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+        switch(requestCode) {
+            case MY_PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE:
+                // If the request is cancelled, the grantResults array is empty
+                if ((grantResults.length > 0) && (grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
+                    displayPDF();
+                } else {
+                    // Permission denied by user.
+                    Snackbar permissionDeniedSnackbar = Snackbar.make(getCurrentFocus(), "Please allow SEPTT access to your files, in order to view the training documents.", Snackbar.LENGTH_LONG);
+                    permissionDeniedSnackbar.show();
+                }
+                return;
+        }
     }
 }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-
-</PreferenceScreen>
+<paths>
+    <external-path path="SEPTT/Training/" name="training_documents_root" />
+</paths>


### PR DESCRIPTION
- Added an appropriate message to be displayed if user doesn't have a PDF Viewer installed, instead of the app crashing.
- Request permission to write to external storage on Android 6.0+
- Add a file provider for opening PDFs on Android 7.0+
